### PR TITLE
Add .travis.yml and update README.md for binary releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+distro: trusty
+language: go
+
+go:
+  - 1.8
+
+script:
+  - curl https://glide.sh/get | sh
+  - go get github.com/mitchellh/gox
+  - glide install --strip-vendor
+  - gox -osarch="darwin/amd64 linux/amd64 linux/arm windows/amd64" -output="bin/ktail-{{.OS}}-{{.Arch}}"
+
+deploy:
+  provider: releases
+  api_key:
+    secure: $ENCRYPTED_GITHUB_TOKEN
+  file_glob: true
+  file: bin/*
+  skip_cleanup: true
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ $ brew tap atombender/ktail
 $ brew install atombender/ktail/ktail
 ```
 
+## Binary installation
+Precompiled binaries for Windows, OS X, Linux are available on the [GitHub release page](https://github.com/atombender/ktail/releases).
+
+### Linux and macOS:
+```shell
+# Linux
+curl -L https://github.com/atombender/ktail/releases/download/v0.5.1/ktail-linux-amd64 -o ktail
+
+# macOS
+curl -L https://github.com/atombender/ktail/releases/download/v0.5.1/ktail-darwin-amd64 -o ktail
+
+chmod +x ktail
+sudo mv ./ktail /usr/local/bin/ktail
+```
+
+### Windows:
+Download from [GitHub](https://github.com/atombender/ktail/releases/download/v0.5.1/ktail-windows-amd64.exe) and add the binary to your `PATH`.
+
 ## From source
 
 This requires [Glide](https://glide.sh/) and Go >= 1.7.


### PR DESCRIPTION
The `.travis.yml` will cause Travis (when linked up) to build `ktail` binaries for common platforms, then use the encrypted GitHub OAuth token in `ENCRYPTED_GITHUB_TOKEN` (which you'll have to configure in Travis) to add the binaries to tagged releases. You can see an example of what it'll look like on [my fork](https://github.com/Code0x58/ktail/releases/).

This approach does mean that the `README.md` should be updated in commit that is tagged for release so the installation documentation is kept up to date.