### PR TITLE
add shorthand for `since-start`

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	flags.BoolVarP(&raw, "raw", "r", false, "Don't format output; output messages only (unless --timestamps)")
 	flags.BoolVarP(&timestamps, "timestamps", "T", false, "Include timestamps on each line")
 	flags.BoolVarP(&quiet, "quiet", "q", false, "Don't print events about new/deleted pods")
-	flags.BoolVarP(&sinceStart, "since-start", "", false,
+	flags.BoolVarP(&sinceStart, "since-start", "f", false,
 		"Start reading log from the beginning of the container's lifetime.")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	flags.BoolVarP(&raw, "raw", "r", false, "Don't format output; output messages only (unless --timestamps)")
 	flags.BoolVarP(&timestamps, "timestamps", "T", false, "Include timestamps on each line")
 	flags.BoolVarP(&quiet, "quiet", "q", false, "Don't print events about new/deleted pods")
-	flags.BoolVarP(&sinceStart, "since-start", "f", false,
+	flags.BoolVarP(&sinceStart, "since-start", "s", false,
 		"Start reading log from the beginning of the container's lifetime.")
 
 	if err := flags.Parse(os.Args[1:]); err != nil {


### PR DESCRIPTION
This makes `--since-start` inline with `kubectl logs -f`. 
`--since-start` flag seems to do almost the same thing as `--follow` flag in `kubectl` except I have to do
```
ktail foo --since-start
```

I think adding `-f` shorthand for `--since-start` will make it inline with `kubectl log foo -f` i.e.,
```
ktail foo -f
```