### PR TITLE
Multi-container pod tailing, duplicate tails fixes

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -267,7 +267,7 @@ func (ctl *Controller) getStartTimestamp(
 }
 
 func buildKey(pod *v1.Pod, container *v1.Container) string {
-	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	return fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Name)
 }
 
 func allContainerStatusesForPod(pod *v1.Pod) []v1.ContainerStatus {

--- a/controller.go
+++ b/controller.go
@@ -270,15 +270,6 @@ func buildKey(pod *v1.Pod, container *v1.Container) string {
 	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }
 
-func findContainerID(pod *v1.Pod, container *v1.Container) string {
-	for _, c := range allContainerStatusesForPod(pod) {
-		if c.Name == container.Name {
-			return c.ContainerID
-		}
-	}
-	return container.Name // Fallback, should never happen
-}
-
 func allContainerStatusesForPod(pod *v1.Pod) []v1.ContainerStatus {
 	statuses := make([]v1.ContainerStatus, len(pod.Status.ContainerStatuses)+len(pod.Status.InitContainerStatuses))
 	return append(

--- a/tailer.go
+++ b/tailer.go
@@ -92,7 +92,7 @@ func (ct *ContainerTailer) runStream(stream io.ReadCloser) error {
 	}()
 
 	r := bufio.NewReader(stream)
-	for {
+	for !ct.stop {
 		line, err := r.ReadString('\n')
 		if err != nil {
 			if err != io.EOF {
@@ -103,6 +103,7 @@ func (ct *ContainerTailer) runStream(stream io.ReadCloser) error {
 		ct.errorBackoff.Reset()
 		ct.receiveLine(line)
 	}
+	return nil
 }
 
 func (ct *ContainerTailer) receiveLine(s string) {


### PR DESCRIPTION
Despite PR #17, the current main can still duplicate container tails. That PR also introduced a regression that causes only one container to be tailed from a pod with multiple containers.

Repro - note that you may need to update the stateful set multiple times as the duplicate tailing doesn't necessarily occur every time:
1. Start ktail:
```
[ktail (main-)]$ ktail -lapp ktail-test --timestamps
```
2. Apply the following stateful set:
```
[ktail (main-)]$ kubectl apply -f -
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ktail-test
spec:
  selector:
    matchLabels:
      app: ktail-test
  serviceName: ktail-test
  replicas: 1
  template:
    metadata:
      labels:
        app: ktail-test
      annotations:
        foo: a
    spec:
      containers:
      - name: c1
        image: bash:latest
        command:
          - bash
          - -c
          - "x=1; while true; do echo $x; x=$((x+1)); sleep 1; done"
      - name: c2
        image: bash:latest
        command:
          - bash
          - -c
          - "x=1; while true; do echo $x; x=$((x+1)); sleep 1; done"
statefulset.apps/ktail-test created
```
3. Observe that only one of the containers is tailed:
```
[ktail (main-)]$ ktail -lapp ktail-test --timestamps
==> New container [ktail-test-0:c1]
==> New container [ktail-test-0:c2]
==> New container [ktail-test-0:c1]
2022-07-31 18:44:56.137848218 +0000 UTC ktail-test-0:c1 1
2022-07-31 18:44:57.139114374 +0000 UTC ktail-test-0:c1 2
2022-07-31 18:44:58.140316102 +0000 UTC ktail-test-0:c1 3
2022-07-31 18:44:59.141517492 +0000 UTC ktail-test-0:c1 4
2022-07-31 18:45:00.142660184 +0000 UTC ktail-test-0:c1 5
2022-07-31 18:45:01.143851672 +0000 UTC ktail-test-0:c1 6
2022-07-31 18:45:02.144969138 +0000 UTC ktail-test-0:c1 7
2022-07-31 18:45:03.146063988 +0000 UTC ktail-test-0:c1 8
2022-07-31 18:45:04.147207492 +0000 UTC ktail-test-0:c1 9
2022-07-31 18:45:05.148722608 +0000 UTC ktail-test-0:c1 10
```
4. Apply the stateful set again with an altered the `foo` annotation value:
```
[ktail (main-)]$ kubectl apply -f -
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ktail-test
spec:
  selector:
    matchLabels:
      app: ktail-test
  serviceName: ktail-test
  replicas: 1
  template:
    metadata:
      labels:
        app: ktail-test
      annotations:
        foo: b
    spec:
      containers:
      - name: c1
        image: bash:latest
        command:
          - bash
          - -c
          - "x=1; while true; do echo $x; x=$((x+1)); sleep 1; done"
      - name: c2
        image: bash:latest
        command:
          - bash
          - -c
          - "x=1; while true; do echo $x; x=$((x+1)); sleep 1; done"
statefulset.apps/ktail-test configured
```
6.  Observe two tails occurring for the one container that is being tailed.
```
2022-07-31 18:50:18.37143432 +0000 UTC ktail-test-0:c1 158
2022-07-31 18:50:19.3726387 +0000 UTC ktail-test-0:c1 159
2022-07-31 18:50:20.373825931 +0000 UTC ktail-test-0:c1 160
2022-07-31 18:50:21.375127732 +0000 UTC ktail-test-0:c1 161
==> Container left (waiting) [ktail-test-0:c1]
==> New container [ktail-test-0:c1]
==> New container [ktail-test-0:c2]
==> New container [ktail-test-0:c1]
2022-07-31 18:50:25.302927917 +0000 UTC ktail-test-0:c1 1
2022-07-31 18:50:26.304258933 +0000 UTC ktail-test-0:c1 2
2022-07-31 18:50:25.302927917 +0000 UTC ktail-test-0:c1 1
2022-07-31 18:50:26.304258933 +0000 UTC ktail-test-0:c1 2
2022-07-31 18:50:27.305345594 +0000 UTC ktail-test-0:c1 3
2022-07-31 18:50:27.305345594 +0000 UTC ktail-test-0:c1 3
2022-07-31 18:50:28.306654222 +0000 UTC ktail-test-0:c1 4
2022-07-31 18:50:28.306654222 +0000 UTC ktail-test-0:c1 4
2022-07-31 18:50:29.307982535 +0000 UTC ktail-test-0:c1 5
2022-07-31 18:50:29.307982535 +0000 UTC ktail-test-0:c1 5
2022-07-31 18:50:30.309096542 +0000 UTC ktail-test-0:c1 6
2022-07-31 18:50:30.309096542 +0000 UTC ktail-test-0:c1 6
2022-07-31 18:50:31.310262842 +0000 UTC ktail-test-0:c1 7
2022-07-31 18:50:31.310262842 +0000 UTC ktail-test-0:c1 7
2022-07-31 18:50:32.311563671 +0000 UTC ktail-test-0:c1 8
2022-07-31 18:50:32.311563671 +0000 UTC ktail-test-0:c1 8
2022-07-31 18:50:33.312661348 +0000 UTC ktail-test-0:c1 9
2022-07-31 18:50:33.312661348 +0000 UTC ktail-test-0:c1 9
2022-07-31 18:50:34.313957002 +0000 UTC ktail-test-0:c1 10
2022-07-31 18:50:34.313957002 +0000 UTC ktail-test-0:c1 10
```

I believe this PR fixes both of the above issues, as well as issue #18.

Context for the changes:
1. Prior to #17 the tailer key differentiated by container ID, but that is not always populated, and thus could result in duplicate container tails. As such, the container ID was removed from the tailer key. However, that meant that only one container per pod could be tailed.
 
    https://github.com/atombender/ktail/commit/8623cabc1acb4b0ed52e51e0bd6390ab0d03a80d updates the tail key to differentiate by container name to allow for multiple containers per pod to be tailed without the issue of container ID sometimes not being populated. I believe using container name should be sufficient.

3. In my debugging, I observed that in the tailer `runStream` loop, `EOF` may be read before `Stop` is called and before current `Run` loop calls `runStream`. In that case we may get a duplicate tail as the controller may have initiated a new tail, but the existing `runStream` loop would continue indefinitely.

 
   https://github.com/atombender/ktail/commit/f917806999776a1bccf6141a45d6ece60364a8e1 adds a check to the `runStream` loop to see if the controller has attempted to stop the given tailer.